### PR TITLE
Readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ But if you're gonna anyways, do like this!
 1. I need to live in your blogs gitrepo; `Fabric` needs to be able to find me as
 your `fabfile`. This means:
 ```bash
-                ## Just name the repo fabric:
-                        git clone git@github.com:Gastove/blogric.git fabfile
+## Just name the repo fabric:
+git clone git@github.com:Gastove/blogric.git fabfile
 
-                                ## OR
-                                        git clone git@github.com:Gastove/blogric.git && ln -s ./blogric ./fabfile
+## OR
+git clone git@github.com:Gastove/blogric.git && ln -s ./blogric ./fabfile
 ```
 2. (This says 1 again because Github is a Jerk about Numbers. So I'm going to
 sulk, and you can meet me at the next enumeration.)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Hi! I'm `blogric`. I'm a tiny little [Fabric](http://www.fabfile.org/) library
 for blogging with [Pelican](http://blog.getpelican.com/) and
 [Github Pages](https://pages.github.com/). I make a looooot of assumptions,
-because _mostly_ I'm for @gastove to use for his [assorted](blog.gastove.com)
-[blags](food.gastove.com). If you wanna use me, you should probably:
+because _mostly_ I'm for @gastove to use for his [assorted](http://blog.gastove.com/)
+[blags](http://food.gastove.com). If you wanna use me, you should probably:
 
 1. not.
 


### PR DESCRIPTION
Fixed blog links that were being interpreted as relative paths and de-weirdified the indentation in the first code block. :smile_cat: 
